### PR TITLE
Update site-doc.vugu

### DIFF
--- a/site-doc.vugu
+++ b/site-doc.vugu
@@ -1097,10 +1097,6 @@ func (comp *MyLine) NewData(props vugu.Props) (interface{}, error) {
         file-name="example.txt" :line-number="i">
     </ul>
 </div>
-
-<script type="application/x-go">
-import "math/rand"
-</script>
 `)'></div>
 
                       <p>

--- a/site-doc.vugu
+++ b/site-doc.vugu
@@ -1095,7 +1095,7 @@ func (comp *MyLine) NewData(props vugu.Props) (interface{}, error) {
     <ul>
       <my-line vg-for=&apos;i := 0; i < 10; i++&apos; 
         file-name="example.txt" :line-number="i">
-    </li>
+    </ul>
 </div>
 
 <script type="application/x-go">


### PR DESCRIPTION
small typo that made the example code not working.

additionally 
```
go run devserver.go
2019/10/29 15:37:54 Starting HTTP Server at "127.0.0.1:8844"
2019/10/29 15:37:59 Error from compile: exit status 2 (out path="/tmp/main_wasm_410868343"); Output:
# github.com/bh90210/grs/vuguTest
./root.go:9:8: imported and not used: "math/rand"
```
fixed it by removing the `<script>` tag. 