### PR TITLE
Fix quotes in the doc page about routing

### DIFF
--- a/app/pages/doc/routing.vugu
+++ b/app/pages/doc/routing.vugu
@@ -100,8 +100,8 @@ func vuguSetup(buildEnv *vugu.BuildEnv, eventEnv vugu.EventEnv) vugu.Builder {
     <vg-comp expr="c.Body"/>
 
     <!-- USE Navigator.Navigate() TO CHANGE TO A DIFFERENT URL-->
-    <button @click="c.Navigate("/", nil)">Home</button>
-    <button @click="c.Navigate("/page2", nil)">Page2</button>
+    <button @click='c.Navigate("/", nil)'>Home</button>
+    <button @click='c.Navigate("/page2", nil)'>Page2</button>
 
 </div>
 


### PR DESCRIPTION
When copy pasting the code from docs, it does not work because double quotes are used and inside them there are another double quotes. I changed outer quotes to be single quotes.