### PR TITLE
Change getting started instructions for go1.17+

### DIFF
--- a/app/pages/doc/start.vugu
+++ b/app/pages/doc/start.vugu
@@ -33,8 +33,16 @@
                       <li><div>
                         <p>
                           <strong>Install vgrun and related utilities</strong> with the commands:
-<div vg-html='codefmt.Show("bash",`go get -u github.com/vugu/vgrun
-vgrun -install-tools`)'></div>                            
+                        </p>
+                        <p>
+                          <strong>go1.17 and newer:</strong>
+<div vg-html='codefmt.Show("bash",`go install github.com/vugu/vgrun
+vgrun -install-tools`)'></div>                   
+                        </p>
+                        <p>
+                          <strong>go versions earlier than 1.17:</strong>         
+                          <div vg-html='codefmt.Show("bash",`go get -u github.com/vugu/vgrun
+vgrun -install-tools`)'></div>                   
                         </p>
                       </div></li>
 


### PR DESCRIPTION
Go1.17 starts to show users a deprecation messages when go get is used for installing binaries.
This change adds two different install directions for different go versions, one for go1.17+ and one for older versions.
Also fixes the bug report in the vugu main repo: https://github.com/vugu/vugu/issues/210